### PR TITLE
Allowing merge files to contain a index integer versus a named object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules/
 coverage/
-blocks/
-models/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 coverage/
+blocks/
+models/

--- a/README.md
+++ b/README.md
@@ -68,8 +68,14 @@ will be merged to
 It is also possible to reference nested objects in other files
 
 ```json
+// Support named nested objects
 {
     "...": "./other.json#/some/key"
+}
+
+// Support array indexes
+{
+    "...": "./other.json#/some/0/name"
 }
 ```
 
@@ -82,5 +88,14 @@ When merging arrays path patterns can be used to merge 0..n objects into the arr
     { "...": "../*/component.json" }
 ]
 ````
+
+### Mergin multiple JSON files into one
+```json
+// Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
+{
+    "...": "./file1.json#/some/name",
+    "...1": "./file2.json#/some/0/array-item"
+}
+```
 
 If the source object only contains the spread operator and the target object is an array, the array items will be spliced into the source array at the position of the source object.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ When merging arrays path patterns can be used to merge 0..n objects into the arr
 ]
 ````
 
-### Mergin multiple JSON files into one
+### Merge multiple JSON files into one
 
 Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ will be merged to
 It is also possible to reference nested objects in other files
 
 ```json
-// Support named nested objects
 {
     "...": "./other.json#/some/key"
 }
+```
 
-// Support array indexes
+Support for merging array indexes buy its key
+
+```json
 {
     "...": "./other.json#/some/0/name"
 }
@@ -90,8 +92,10 @@ When merging arrays path patterns can be used to merge 0..n objects into the arr
 ````
 
 ### Mergin multiple JSON files into one
+
+Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
+
 ```json
-// Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
 {
     "...": "./file1.json#/some/name",
     "...1": "./file2.json#/some/0/array-item"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merge-json-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merge-json-cli",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/src/merge.js
+++ b/src/merge.js
@@ -8,7 +8,7 @@ async function readJsonFile(path) {
   return JSON.parse(fileContent);
 }
 
-function findRef(path, object, origianlPath = path) {
+function findRef(path, object, originalPath = path) {
   if (path === '/' || path === '') {
     return object;
   }
@@ -17,14 +17,19 @@ function findRef(path, object, origianlPath = path) {
   const key = parts.shift();
   let nextObject;
   if (Array.isArray(object)) {
-    nextObject = object.find((item) => item.id === key || item.name === key);
+    if (!isNaN(key)) {
+      // If the key is a number, use it as an array index so when in json files, we can properly target /0/fields or other indexes
+      nextObject = object[parseInt(key, 10)];
+    } else {
+      nextObject = object.find((item) => item.id === key || item.name === key);
+    }
   } else if (typeof object === 'object') {
     nextObject = object[key];
   }
   if (!nextObject) {
-    throw new Error(`Reference '${origianlPath}' not found`);
+    throw new Error(`Reference '${originalPath}' not found`);
   }
-  return findRef(`/${parts.join('/')}`, nextObject, origianlPath);
+  return findRef(`/${parts.join('/')}`, nextObject, originalPath);
 }
 
 async function walk(file, object, self = object) {


### PR DESCRIPTION
In the current file, if we attempted to import a nested object like so `/models/_title.json#/models/0/fields` which was part of an array, the script would fail as:
1. It is looking for a named "0" versus an index of 0 
2. It could not find a object name of 0

I've made the following changes:
1. Updated a var name from a small spelling mistake
2. Added an additional check in findRef to check if the array contains a number 
3. If number is found, it looks for the corresponding index
4. If no number, it looks for the named field. 

Beforehand, an import of `/models/_title.json#/models/0/fields` but a `/models/_title.json#/models` would work. 

After the change, both importing methods above work as expected. 

Sample json to test within a xwalk-boilerplate project
```
{
    "definitions" :[
      {
        "title": "Flight Deals",
        "id": "flightDeals",
        "plugins": {
          "xwalk": {
            "page": {
              "resourceType": "core/franklin/components/block/v1/block",
              "template": {
                "name": "Flight Deals",
                "model": "flightDeals",
                "key-value": true
              }
            }
          }
        }
      }
    ],
    "models": [
      {
        "fields": [
          {
            "...": "../../../models/_title.json#/models/0/fields"
          }
        ]
      }
    ],
    "filters": []
  }
```