### PR TITLE
Fixing the nested objects bug referenced in issue #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules/
 coverage/
-blocks/
-models/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 coverage/
+blocks/
+models/

--- a/README.md
+++ b/README.md
@@ -68,8 +68,14 @@ will be merged to
 It is also possible to reference nested objects in other files
 
 ```json
+// Support named nested objects
 {
     "...": "./other.json#/some/key"
+}
+
+// Support array indexes
+{
+    "...": "./other.json#/some/0/name"
 }
 ```
 
@@ -82,5 +88,14 @@ When merging arrays path patterns can be used to merge 0..n objects into the arr
     { "...": "../*/component.json" }
 ]
 ````
+
+### Mergin multiple JSON files into one
+```json
+// Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
+{
+    "...": "./file1.json#/some/name",
+    "...1": "./file2.json#/some/0/array-item"
+}
+```
 
 If the source object only contains the spread operator and the target object is an array, the array items will be spliced into the source array at the position of the source object.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ When merging arrays path patterns can be used to merge 0..n objects into the arr
 ]
 ````
 
-### Mergin multiple JSON files into one
+### Merge multiple JSON files into one
 
 Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ will be merged to
 It is also possible to reference nested objects in other files
 
 ```json
-// Support named nested objects
 {
     "...": "./other.json#/some/key"
 }
+```
 
-// Support array indexes
+Support for merging array indexes buy its key
+
+```json
 {
     "...": "./other.json#/some/0/name"
 }
@@ -90,8 +92,10 @@ When merging arrays path patterns can be used to merge 0..n objects into the arr
 ````
 
 ### Mergin multiple JSON files into one
+
+Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
+
 ```json
-// Added the ability to merge multiple JSON files into one as code looks for any key starting with ...
 {
     "...": "./file1.json#/some/name",
     "...1": "./file2.json#/some/0/array-item"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merge-json-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merge-json-cli",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "^3.3.2",

--- a/src/merge.js
+++ b/src/merge.js
@@ -8,7 +8,7 @@ async function readJsonFile(path) {
   return JSON.parse(fileContent);
 }
 
-function findRef(path, object, origianlPath = path) {
+function findRef(path, object, originalPath = path) {
   if (path === '/' || path === '') {
     return object;
   }
@@ -17,14 +17,19 @@ function findRef(path, object, origianlPath = path) {
   const key = parts.shift();
   let nextObject;
   if (Array.isArray(object)) {
-    nextObject = object.find((item) => item.id === key || item.name === key);
+    if (!isNaN(key)) {
+      // If the key is a number, use it as an array index so when in json files, we can properly target /0/fields or other indexes
+      nextObject = object[parseInt(key, 10)];
+    } else {
+      nextObject = object.find((item) => item.id === key || item.name === key);
+    }
   } else if (typeof object === 'object') {
     nextObject = object[key];
   }
   if (!nextObject) {
-    throw new Error(`Reference '${origianlPath}' not found`);
+    throw new Error(`Reference '${originalPath}' not found`);
   }
-  return findRef(`/${parts.join('/')}`, nextObject, origianlPath);
+  return findRef(`/${parts.join('/')}`, nextObject, originalPath);
 }
 
 async function walk(file, object, self = object) {

--- a/src/merge.js
+++ b/src/merge.js
@@ -18,12 +18,18 @@ function findRef(path, object, originalPath = path) {
 
   for (const part of parts) {
     if (Array.isArray(current)) {
-      // If we're looking for any property in an array of objects, find the first object with that property
-      const foundObject = current.find(item => item[part] !== undefined);
-      if (foundObject) {
-        current = foundObject[part];
+      if (/^\d+$/.test(part)) {
+        // If the part is a number, use it as an index
+        const index = parseInt(part, 10);
+        current = current[index];
       } else {
-        current = current.find(item => item.id === part);
+        // If no index is specified, default to the first item (index 0)
+        const foundObject = current.find(item => item[part] !== undefined);
+        if (foundObject) {
+          current = foundObject[part];
+        } else {
+          current = current[0] && current[0][part];
+        }
       }
     } else if (typeof current === 'object' && current !== null) {
       current = current[part];


### PR DESCRIPTION
After verifying the nested object issue with a vanilla project, I have applied the following fix to address JSONf files being able to both import as so:

```json
{
 "...": "../../models/_title.json#/models/fields"
},
{
 "...": "../../models/_title.json#/models/1/fields"
}
```

See the associated issue for more clarity on context and usage, https://github.com/buuhuu/merge-json-cli/issues/2